### PR TITLE
Fix random quote selection

### DIFF
--- a/Kiara_bot.js
+++ b/Kiara_bot.js
@@ -836,7 +836,7 @@ client.on('message', async (channel, tags, message, self) => {
 
             //generate a random quote if no number specified
             if (quote_ID === '') {
-                var quote_ID = Math.floor(Math.random() * quote_Count) + 1;
+                var quote_ID = Math.floor(Math.random() * quote_Count + 1);
             }
 
 


### PR DESCRIPTION
The only way that the bot could still break after this PR is if Math.random() returns a 1 (impossible) or that a quote is missing from the list, but still has a number reserved.