### PR TITLE
Better badge handling

### DIFF
--- a/Kiara_bot.js
+++ b/Kiara_bot.js
@@ -271,7 +271,7 @@ const allBadges = {};
 /**
  * Add a badge API request's response data to the provided target object.
  * @param {Object} target - The target object to add the badge data to.
- * @param {Object} source - The source object containing the Twitch badge data.
+ * @param {Object[]} source - The source object containing the Twitch badge data.
  */
 function addTwitchBadges(target, source) {
     for (const { set_id, versions } of source) {
@@ -311,8 +311,8 @@ async function getBadgeVersion(set_id, version_id) {
 
             // merge all kinds of badges into tempBadges first, so we don't partially fill allBadges and have an error partway through
             const tempBadges = {};
-            addTwitchBadges(tempBadges, channelBadges);
             addTwitchBadges(tempBadges, globalBadges);
+            addTwitchBadges(tempBadges, channelBadges);
 
             // merge tempBadges into allBadges
             Object.assign(allBadges, tempBadges);

--- a/Kiara_bot.js
+++ b/Kiara_bot.js
@@ -249,21 +249,90 @@ function getChannelInfo(broadcaster_id) {
     });
 }
 
-function getChannelBadges(broadcaster_id) {
+// #region ==================== BADGES =====================
+
+/**
+ * Map of badge set IDs and version IDs to the original version objects from Twitch.
+ * Easier data structure to work with than the original API response.
+ * @example
+ * {
+ *   "bits": {
+ *     "1": {
+ *       "image_url_4x": "https://path.to/some/badge.jpg",
+ *       // many other properties
+ *     },
+ *     // many other versions
+ *   },
+ *   // many other sets
+ * }
+ */
+const allBadges = {};
+
+/**
+ * Add a badge API request's response data to the provided target object.
+ * @param {Object} target - The target object to add the badge data to.
+ * @param {Object} source - The source object containing the Twitch badge data.
+ */
+function addTwitchBadges(target, source) {
+    for (const { set_id, versions } of source) {
+        if (!target[set_id]) {
+            // if the set_id doesn't exist in target, create an empty placeholder for later
+            target[set_id] = {};
+        }
+        versions.forEach(version => {
+            target[set_id][version.id] = version;
+        });
+    }
+}
+
+function getChannelBadges() {
     return new Promise((resolve, reject) => {
-        apiGetRequest('chat/badges', { broadcaster_id: broadcaster_id })
+        apiGetRequest("chat/badges", { broadcaster_id: broadcasterID })
             .then(data => resolve(data.data))
             .catch(error => reject(error))
     });
 }
 
-function getGlobalBadges(broadcaster_id) {
+function getGlobalBadges() {
     return new Promise((resolve, reject) => {
-        apiGetRequest('chat/badges/global', { broadcaster_id: broadcaster_id })
+        apiGetRequest("chat/badges/global")
             .then(data => resolve(data.data))
             .catch(error => reject(error))
     });
 }
+
+async function getBadgeVersion(set_id, version_id) {
+    // if there are no badges loaded yet...
+    if (Object.keys(allBadges).length < 1) {
+        try {
+            // fetch badges from Twitch API
+            const channelBadges = await getChannelBadges();
+            const globalBadges = await getGlobalBadges();
+
+            // merge all kinds of badges into tempBadges first, so we don't partially fill allBadges and have an error partway through
+            const tempBadges = {};
+            addTwitchBadges(tempBadges, channelBadges);
+            addTwitchBadges(tempBadges, globalBadges);
+
+            // merge tempBadges into allBadges
+            Object.assign(allBadges, tempBadges);
+        }
+        catch (error) {
+            console.log("Total failure fetching badges:", error);
+        }
+    }
+    const set = allBadges[set_id];
+    if (set) {
+        const version = set[version_id];
+        if (version) {
+            return version;
+        }
+    }
+    console.log(`Badge version not found for set_id: ${set_id}, version_id: ${version_id}`);
+    return undefined;
+}
+
+// #endregion ==================== BADGES =====================
 
 
 function serverBoop(user_id, duration, reason) {
@@ -563,23 +632,23 @@ function updateIncentiveFile() {
         }
     });
 }
-let channelBadges;
+
 //connect to chat
 client.connect();
 
 //message handler
 client.on('message', async (channel, tags, message, self) => {
     //send to websocket
-    if (!channelBadges){
-        channelBadges=[];
-        channelBadges.push(...await getChannelBadges(broadcasterID));
-        channelBadges.push(...await getGlobalBadges(""));
-
-
-
-    }
     if (websocket && websocket.readyState === WebSocket.OPEN) {
-        websocket.send(JSON.stringify({ kiawaAction: "Message",channel, tags, message, channelBadges }));
+        const messageBadges = [];
+        for (const [setId, versionId] of Object.entries(tags.badges)) {
+            const version = await getBadgeVersion(setId, versionId);
+            if (version) {
+                messageBadges.push(version);
+            }
+        }
+
+        websocket.send(JSON.stringify({ kiawaAction: "Message", channel, tags, message, messageBadges }));
     } else {
         //console.log('WebSocket is not connected. Message not sent.');
     }

--- a/kiawa_Chat_Widget.html
+++ b/kiawa_Chat_Widget.html
@@ -64,7 +64,7 @@
               userBanned(data.modAction)
           }
           else if(data.kiawaAction==="Message"){
-          addMessage(data.tags, data.tags["display-name"],data.message, data.channelBadges)
+          addMessage(data.tags, data.tags["display-name"],data.message, data.messageBadges)
           }
           else{
             console.log('unhandled kiawa Action')
@@ -110,7 +110,7 @@
             }
         }
         // Function to add a new message to the chat window
-        function addMessage(tags, username, message, channelBadges) {
+        function addMessage(tags, username, message, messageBadges) {
           const chatMessages = document.getElementById('chat-messages');
           //pull the userid color
           let userColor=tags.color;
@@ -122,37 +122,15 @@
             userColor='#105584'
           }
 
-          //get badge images, if any
-          let badgeIcons="";
-          let subBadgeID="";
-          let badgeURL="";
-          if (tags.badges){
-                //define the container for all of the badge urls
-                let chatBadges=[];
-                  console.log(channelBadges)
-                  //run through the list of global and channel badges, compare message tags for set Id and version Id of the badges for the user
-                  for (const [setId, versionId] of Object.entries(tags.badges)) {
-                    const set=Object.entries(channelBadges).find(([arrayIndex, cb]) => cb.set_id == setId);
-                    console.log(set)
-                    if (!set) continue;
-                    const version =Object.entries(set[1].versions).find(([arrayIndex, v])=> v.id == versionId);
-                    console.log(version)
-                    if (!version) continue;
-                    const imageUrl= version[1].image_url_4x;
-                    chatBadges.push(imageUrl);
-                  }
-                //combine all the chat badges into one line of html
-                for (const chatBadge of chatBadges) {
-
-                  //the part before the emote code
-                  const badgeElement = document.createElement("img");
-                  badgeElement.src=`${chatBadge}`
-
-                  //assign emote class for basic formatting
-                  badgeElement.classList.add("badges")
-                  badgeIcons=badgeIcons+badgeElement.outerHTML;
-                }
-          }
+          // Kiara_bot.js has already read tags.badges and picked out exactly what this message needs, so we can just read image URLs from the messageBadges
+          const badgeIcons = messageBadges.map(version => {
+            const badgeElement = document.createElement("img");
+            badgeElement.src = version.image_url_4x;
+            badgeElement.classList.add("badges")
+            return badgeElement.outerHTML;
+          })
+          .join(""); // combine all the chat badges into one line of html
+                
           //Check for emotes
           if (tags.emotes){
 


### PR DESCRIPTION
Consolidate more badge code into the bot.  Send only necessary badge data with each message to chat widget.  Handle channel badges overriding global ones, and safely ignore missing badge data.

Since we have no testing support yet, this may need some minor tweaks and fixes to work properly.