### PR TITLE
Add FileCacheService.js and example for easy data persistence

### DIFF
--- a/FileCacheService.js
+++ b/FileCacheService.js
@@ -1,0 +1,70 @@
+import { default as fs } from "fs";
+import { default as path } from "path";
+
+const caches = new Map();
+
+function readFileJson(absolutePath) {
+	if (fs.existsSync(absolutePath)) {
+		// file exists, let's try to read and parse it
+		let content;
+		// read it
+		try {
+			content = fs.readFileSync(absolutePath, "utf-8");
+		} catch (e) {
+			// Reading failed, but the file DID exist.  Maybe file permission issues?  Can't continue in this case without clobbering the file.
+			console.log(`File ${absolutePath} exists but could not be read.`, e);
+			throw e;
+		}
+		
+		let data;
+		try {
+			data = JSON.parse(content);
+		} catch (e) {
+			// File does not contain valid JSON.
+			console.log(`File ${absolutePath} is not valid JSON.`, e);
+			throw e;
+		}
+
+		return data;
+	} else {
+		// File doesn't exist.  Initialize it to make sure file permissions will work later.
+		console.log(`File ${absolutePath} not found; initializing file with empty object.`);
+		const data = {};
+		writeFileJson(absolutePath, data);
+		return data;
+	}
+}
+
+function writeFileJson(absolutePath, data) {
+	fs.writeFileSync(absolutePath, JSON.stringify(data, null, 2), "utf-8");
+}
+
+export function buildFileCache(filePath) {
+	// turn any relative path like "something.json" into "C:\Users\anyia\path\to\kiawaBot\something.json"
+	const absolutePath = path.resolve(path.dirname("."), filePath);
+	
+	// if we don't already have a file cache created for this path, make one
+	if (!caches.has(absolutePath)) {
+		// read the data that's already in the file, to start with
+		const initialData = readFileJson(absolutePath);
+
+		// make a method wrapper that also writes any data changes to the filesystem
+		function buildFileCachingHook(method) {
+			return function fileCachingHook() {
+				console.log("hook called for", method)
+				const result = Reflect[method].apply(cache, arguments); // do the original method call
+				writeFileJson(absolutePath, cache); // write the updated cache object out to disk
+				return result; // return whatever the original method would have returned
+			};
+		}
+
+		const cache = new Proxy(initialData, {
+			set: buildFileCachingHook("set"), // when setting a property directly on the cache, write it to disk
+			deleteProperty: buildFileCachingHook("deleteProperty"), // when deleting a property directly from the cache, write it to disk
+		});
+
+		caches.set(absolutePath, cache); // save the cache for later, so anyone using the equivalent path will share the same Proxy
+	}
+
+	return caches.get(absolutePath); // return the cached Proxy
+}

--- a/FileCacheService.js
+++ b/FileCacheService.js
@@ -51,7 +51,6 @@ export function buildFileCache(filePath) {
 		// make a method wrapper that also writes any data changes to the filesystem
 		function buildFileCachingHook(method) {
 			return function fileCachingHook() {
-				console.log("hook called for", method)
 				const result = Reflect[method].apply(cache, arguments); // do the original method call
 				writeFileJson(absolutePath, cache); // write the updated cache object out to disk
 				return result; // return whatever the original method would have returned

--- a/FileCacheService.js
+++ b/FileCacheService.js
@@ -36,34 +36,51 @@ function readFileJson(absolutePath) {
 }
 
 function writeFileJson(absolutePath, data) {
-	fs.writeFileSync(absolutePath, JSON.stringify(data, null, 2), "utf-8");
+	// convert data to JSON
+	const json = JSON.stringify(data, null, 2);
+	// write JSON to file, clobbering it
+	fs.writeFileSync(absolutePath, json, "utf-8");
 }
 
-export function buildFileCache(filePath) {
+function buildFileProxy(absolutePath) {
+	// read the data that's already in the file, to start with
+	const initialData = readFileJson(absolutePath);
+
+	// make a method wrapper that also writes any data changes to the filesystem
+	function buildFileCachingHook(method) {
+		return function fileCachingHook() {
+			// do the original method call
+			const result = Reflect[method].apply(cache, arguments);
+			// write the updated cache object out to disk
+			writeFileJson(absolutePath, cache);
+			// return whatever the original method would have returned
+			return result;
+		};
+	}
+
+	// create a Proxy starting from the original file data
+	const cache = new Proxy(initialData, {
+		// when setting a property directly on the Proxy, write it to disk
+		set: buildFileCachingHook("set"),
+		// when deleting a property directly from the Proxy, write it to disk
+		deleteProperty: buildFileCachingHook("deleteProperty"),
+	});
+	
+	return cache;
+}
+
+export function getFileCache(filePath) {
 	// turn any relative path like "something.json" into "C:\Users\anyia\path\to\kiawaBot\something.json"
 	const absolutePath = path.resolve(path.dirname("."), filePath);
 	
-	// if we don't already have a file cache created for this path, make one
+	
 	if (!caches.has(absolutePath)) {
-		// read the data that's already in the file, to start with
-		const initialData = readFileJson(absolutePath);
-
-		// make a method wrapper that also writes any data changes to the filesystem
-		function buildFileCachingHook(method) {
-			return function fileCachingHook() {
-				const result = Reflect[method].apply(cache, arguments); // do the original method call
-				writeFileJson(absolutePath, cache); // write the updated cache object out to disk
-				return result; // return whatever the original method would have returned
-			};
-		}
-
-		const cache = new Proxy(initialData, {
-			set: buildFileCachingHook("set"), // when setting a property directly on the cache, write it to disk
-			deleteProperty: buildFileCachingHook("deleteProperty"), // when deleting a property directly from the cache, write it to disk
-		});
-
-		caches.set(absolutePath, cache); // save the cache for later, so anyone using the equivalent path will share the same Proxy
+		// if we don't already have a file cache created for this path, make one
+		const cache = buildFileProxy(absolutePath);
+		// save the cache for later, so anyone using the equivalent path will share the same Proxy
+		caches.set(absolutePath, cache);
 	}
 
-	return caches.get(absolutePath); // return the cached Proxy
+	// return the cached Proxy
+	return caches.get(absolutePath);
 }

--- a/Kiara_bot.js
+++ b/Kiara_bot.js
@@ -20,7 +20,7 @@ const querystring = require('qs');
 const spawn = require('child_process').spawn;
 //Include line reading module
 const fs = require('fs');
-const { buildFileCache } = require("./FileCacheService");
+const { getFileCache } = require("./FileCacheService");
 const t1Value = 3.60;
 const t2Value = 6.00;
 const t3Value = 17.50;
@@ -654,7 +654,7 @@ client.on('message', async (channel, tags, message, self) => {
            }
           websocket.send(JSON.stringify({ kiawaAction: "Message", channel, tags, message, messageBadges }));
           try {
-            const lastChatTimestamps = buildFileCache("lastChatTimestamps.json");
+            const lastChatTimestamps = getFileCache("lastChatTimestamps.json");
             const displayName = tags["display-name"];
             lastChatTimestamps[displayName] = new Date();
           }

--- a/Kiara_bot.js
+++ b/Kiara_bot.js
@@ -20,6 +20,7 @@ const querystring = require('qs');
 const spawn = require('child_process').spawn;
 //Include line reading module
 const fs = require('fs');
+const { buildFileCache } = require("./FileCacheService");
 const t1Value = 3.60;
 const t2Value = 6.00;
 const t3Value = 17.50;
@@ -652,6 +653,15 @@ client.on('message', async (channel, tags, message, self) => {
             }
            }
           websocket.send(JSON.stringify({ kiawaAction: "Message", channel, tags, message, messageBadges }));
+          try {
+            const lastChatTimestamps = buildFileCache("lastChatTimestamps.json");
+            const displayName = tags["display-name"];
+            lastChatTimestamps[displayName] = new Date();
+          }
+          catch (e) {
+            // oops, don't worry about it for this example
+            // console.log("something went wrong saving last timestamp?", e);
+          }
         } else {
             //console.log('WebSocket is not connected. Message not sent.');
         }


### PR DESCRIPTION
Makes reading and saving data to disk between streams (or bot restarts) easier.  Building the cache automatically reads the previous data from disk (or initializes it if necessary).  Writing data to the cache automatically updates the file on disk.