### PR TITLE
fix Windows auth initialization

### DIFF
--- a/Kiara_bot.js
+++ b/Kiara_bot.js
@@ -141,11 +141,14 @@ async function startAuth() {
     });
     const authUrl = new URL("https://id.twitch.tv/oauth2/authorize?" + authQueryString)
     switch (process.platform) {
-        case 'windows':
+        case 'win32':
             await spawn('cmd', ["/c", "start", authUrl]);
             break;
         case 'linux':
             await spawn('xdg-open', [authUrl])
+            break;
+        case 'darwin':
+            await spawn('open', [authUrl])
             break;
         case _:
             console.error(`${process.platform} isn't supported for authentication`)


### PR DESCRIPTION
This is a simple fix for a problem I accidentally introduced when adding Linux auth support, where Windows wouldn't work anymore for starting the initial auth process.
While at it I added MacOS support too.