### PR TITLE
feat: add !removequote command restricted to broadcaster

### DIFF
--- a/Kiara_bot.js
+++ b/Kiara_bot.js
@@ -1498,6 +1498,7 @@ async function messageHandler(tags) {
             const messageBadges = [];
             var ismod=false;
             var isvip=false;
+            var isbroadcaster=false;
             if (tags.badges) {
                 for (const {set_id, id} of tags.badges) {
                     //parse out the badges that are part of this message
@@ -1511,6 +1512,7 @@ async function messageHandler(tags) {
 
                     if(set_id==='broadcaster'){
                         ismod=true;
+                        isbroadcaster=true;
                     }
                     if(set_id==='vip'){
                         isvip=true;
@@ -1760,6 +1762,21 @@ async function messageHandler(tags) {
             }
             else {
                 postMessage(botID, `Quote couldn't be added... check the bot logs. kiawaSad`);
+            }
+        }
+    }
+    
+    if (command === "!removequote") {
+        if (isbroadcaster === true) {
+            if (args.length === 2 && /^\d+$/.test(args[1])) {
+                const removedQuote = quoteData.remove(args[1]);
+                if (removedQuote) {
+                    postMessage(botID, `Removed Quote #${removedQuote.Index}: ${removedQuote.Quote_Text}`);
+                } else {
+                    postMessage(botID, `Could not find Quote #${args[1]} to remove.`);
+                }
+            } else {
+                postMessage(botID, `Usage: !removequote <number>`);
             }
         }
     }

--- a/QuoteHelper.js
+++ b/QuoteHelper.js
@@ -166,4 +166,38 @@ export default class QuoteHelper {
         return undefined;
     }
 
+    /**
+     * @param { any } id
+     * @returns { Quote | undefined } the removed Quote, if any
+     */
+    remove(id) {
+        const index = castIdToString(id);
+        if (id) {
+            this.load();
+            const quoteIndex = this.quotes.findIndex(quote => quote.Index === index);
+            if (quoteIndex !== -1) {
+                const removedQuote = this.quotes.splice(quoteIndex, 1)[0];
+                
+                // Atomically re-index all quotes to perfectly sequential numbering
+                let newId = 1;
+                for (let i = 0; i < this.quotes.length; i++) {
+                    if (this.quotes[i].Index !== undefined) { // Skip metadata element
+                        this.quotes[i].Index = String(newId);
+                        newId++;
+                    }
+                }
+                
+                // Update the Quote_Count metadata element
+                const metadataElement = this.quotes.find(quote => quote.Quote_Count !== undefined);
+                if (metadataElement) {
+                    metadataElement.Quote_Count = String(newId - 1);
+                }
+
+                this.save();
+                return removedQuote;
+            }
+        }
+        return undefined;
+    }
+
 }


### PR DESCRIPTION
Adds the ability to remove quotes from the database via chat using \!removequote <number>\. This command is strictly limited to the broadcaster via Twitch badge verification to prevent abuse.